### PR TITLE
Retry failed diffs, these are seriously annoying

### DIFF
--- a/jenkins-gke-deploy/deploy.sh
+++ b/jenkins-gke-deploy/deploy.sh
@@ -145,7 +145,7 @@ diff() {
 
     local errfile="${TMP_DIR}/diff-${tries}.err"
 
-    if argo_cli app diff "${app}z" --hard-refresh 2>"${errfile}"; then
+    if argo_cli app diff "${app}" --hard-refresh 2>"${errfile}"; then
       cat "${errfile}" >&2
 
       debug "No differences found for ${app}"


### PR DESCRIPTION
For some annoying reason, ArgoCD diff calls are sometimes flaky and fail with error messages like this:

```
msg="rpc error: code = Unknown desc = POST https://ap-argocd.dsp-devops.broadinstitute.org:443/application.ApplicationService/Get failed with status code 502"
```

This happened during today's monolith release, triggering a spurious gke-deploy job for **cromwell** and a "cromwell deploy" notification to the `#workbench-release` Slack channel. This change just adds logic to retry failed diffs. If the diffs fail 3 times, we'll fall back to the current behavior (basically, trigger a sync, as if there were actual diffs).