### PR TITLE
DDO-660 Upgrade to kustomize 3.5.5

### DIFF
--- a/argocd-custom-image/Dockerfile
+++ b/argocd-custom-image/Dockerfile
@@ -9,7 +9,7 @@ ARG vault_version
 
 ARG os=linux
 ARG arch=amd64
-ARG kustomize_version=3.5.4
+ARG kustomize_version=3.5.5
 ARG consul_template_version=0.20.0
 
 RUN echo "ArgoCD version: ${argocd_version}"


### PR DESCRIPTION
Pull in a fix for a [seriously gross bug](https://github.com/kubernetes-sigs/kustomize/issues/2125) in kustomize that corrupts binary data when used with secretGenerator