### PR TITLE
DDO-847 / DDO-900 Add simple helper script for querying terra-helmfile version from Jenkins

### DIFF
--- a/jenkins-get-helmfile-version/Dockerfile
+++ b/jenkins-get-helmfile-version/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.11.5
+
+ARG os=linux
+ARG arch=amd64
+
+RUN apk add curl jq
+
+# TODO - this is only necessary until yq is part of the regular alpine distro
+# https://github.com/mikefarah/yq/issues/190
+RUN apk add yq --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+
+COPY get-helmfile-version.sh /get-helmfile-version.sh
+
+ENTRYPOINT ["/get-helmfile-version.sh"]

--- a/jenkins-get-helmfile-version/README.md
+++ b/jenkins-get-helmfile-version/README.md
@@ -1,0 +1,35 @@
+# jenkins-get-helmfile-version
+
+A Docker image for querying the current version of an application in terra-helmfile.
+
+## Building and publishing a new image
+
+Docker images are automatically built, tagged with `$BRANCH` and `$BRANCH-$GIT_SHA`, and pushed to the `dsp-artifact-registry` GCP project.
+
+The [gke-service-update](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-service-update/) job in Jenkins is configured to pull the latest `main` image.
+
+## Running stable published image
+    #
+    # Set GITHUB_TOKEN to a valid GitHub personal access token w/ read access to terra-helmfile
+    # Set APP to the name of an application, eg. "cromwell"
+    #
+    IMAGE="us-central1-docker.pkg.dev/dsp-artifact-registry/terra-helmfile/jenkins-get-helmfile-version"
+    docker pull "$IMAGE"
+    docker run --rm -it \
+      -e GITHUB_TOKEN=$GITHUB_TOKEN \
+      "${IMAGE}" "${APP}"
+
+    # Report the version of leonardo in versions.yaml:
+    docker run --rm -it \
+      -e GITHUB_TOKEN=$GITHUB_TOKEN \
+      "${IMAGE}" leonardo
+
+### Overriding versions file:
+
+It's possible to query another versions file like this:
+
+    # Report alpha version of Leo
+    docker run --rm -it \
+      -e GITHUB_TOKEN=$GITHUB_TOKEN \
+      -e VERSIONS_FILE=versions/alpha.yaml \
+      "${IMAGE}" leonardo

--- a/jenkins-get-helmfile-version/get-helmfile-version.sh
+++ b/jenkins-get-helmfile-version/get-helmfile-version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+#
+# A script for retrieving the version of an app from terra-helmfile's versions.yaml file, via
+# the GitHub API.
+#
+REPO="broadinstitute/terra-helmfile"
+VERSIONS_FILE=${VERSIONS_FILE:-"versions.yaml"}
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <project>" >&2
+  exit 1
+fi
+
+APP="$1"
+
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo "Error: Please supply a valid GitHub token via the GITHUB_TOKEN environment variable" >&2
+  exit 1
+fi
+
+curl --fail -L -sS \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Authorization: token ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/${REPO}/contents/${VERSIONS_FILE}" |\
+  jq -r '.content' |\
+  base64 -d |\
+  yq read - "releases.${APP}.appVersion" --exitStatus 1


### PR DESCRIPTION
Add a simple helper script for querying latest application version in versions.yaml from Jenkins

This is used by the gke-service-update job to wait to proceed until a version update has actually been merged to master.