### PR TITLE
DDO-1051 Wait for deploys to become healthy

### DIFF
--- a/jenkins-gke-deploy/deploy.sh
+++ b/jenkins-gke-deploy/deploy.sh
@@ -179,7 +179,8 @@ sync() {
 
   argo_cli app sync "${app}" --prune --timeout "${ARGOCD_SYNC_TIMEOUT}"
 
-  # Wait for app to become healthy
+  info "Waiting up to ${ARGOCD_WAIT_TIMEOUT}s for ${app} to become healthy"
+
   argo_cli app wait "${app}" --timeout="${ARGOCD_WAIT_TIMEOUT}"
 }
 


### PR DESCRIPTION
**What:** Update the Jenkins `gke-deploy` job to wait for an application to become healthy in ArgoCD after syncing, with a timeout of 300s.

**Why:** Currently the Jenkins deploy process syncs K8s manifests and moves on without waiting for the Argo application to transition to "Healthy" state. If the new pods fail to start up and the rollout never finishes, the Jenkins job will report to success even though the deploy wasn't actually successful / the old version of the code is still running.