### PR TITLE
Make sure we fail if the sync fails, also bump wait timeout to 10 mins

### DIFF
--- a/jenkins-gke-deploy/deploy.sh
+++ b/jenkins-gke-deploy/deploy.sh
@@ -247,11 +247,11 @@ sync_project(){
 
   if [[ "${has_legacy_configs}" == "true" ]]; then
     diff "${legacy_configs_app}" || true # Print diff
-    sync "${legacy_configs_app}"
+    sync "${legacy_configs_app}" || return 1
   fi
 
   diff "${app}" || true # Print diff
-  sync "${app}"
+  sync "${app}" || return 1
 
   if [[ "${has_legacy_configs}" == "true" ]]; then
     restart "${app}"


### PR DESCRIPTION
* Fix bug where failed syncs would be ignored
* 5 minutes seems to be too slow for DataRepo deploys (and cuts it close for Cromwell), so let's bump to 10 minutes