### PR TITLE
DDO-1319 Add --values-file flag to render

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Broad Institute, Inc., Verily Life Sciences LLC
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terra-helmfile-images
 
 [![codecov](https://codecov.io/gh/broadinstitute/terra-helmfile-images/branch/main/graph/badge.svg?token=QYQHL6UE6Y)](https://codecov.io/gh/broadinstitute/terra-helmfile-images)
-[![Go Report Card](https://goreportcard.com/badge/broadinstitute/terra-helmfile-images/tools](https://goreportcard.com/report/broadinstitute/terra-helmfile-images/tools)
+[![Go Report Card](https://goreportcard.com/badge/github.com/broadinstitute/terra-helmfile-images/tools](https://goreportcard.com/report/github.com/broadinstitute/terra-helmfile-images/tools)
 
 This repository contains accessory tooling for the [terra-helmfile repo](https://github.com/broadinstitute/terra-helmfile). It includes:
 * Golang source code for various utilities for rendering manifests and publishing charts (see `tools/` subdirectory)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # terra-helmfile-images
 
+[![codecov](https://codecov.io/gh/broadinstitute/terra-helmfile-images/branch/main/graph/badge.svg?token=QYQHL6UE6Y)](https://codecov.io/gh/broadinstitute/terra-helmfile-images)
+[![Go Report Card](https://goreportcard.com/badge/broadinstitute/terra-helmfile-images/tools](https://goreportcard.com/report/broadinstitute/terra-helmfile-images/tools)
+
 This repository contains accessory tooling for the [terra-helmfile repo](https://github.com/broadinstitute/terra-helmfile). It includes:
 * Golang source code for various utilities for rendering manifests and publishing charts (see `tools/` subdirectory)
 * Dockerfiles for images that interact with terra-helmfile (see `images/` subdirectory).
@@ -10,13 +13,11 @@ This repository contains accessory tooling for the [terra-helmfile repo](https:/
 
 ### Docker Images
 
-These images depend on tools like `helmfile` and `ArgoCD` in order to work, and it's useful to be able to configure the versions of these tools in a common location. (Currently, the shared `cloudbuild.yml`).
-
 * **`tools`**: [Used by terra-helmfile's render helper script](https://github.com/broadinstitute/terra-helmfile/blob/master/bin/render)
 * **`env-diff-action`**: [Used by terra-helmfile's env-diff GitHub Action](https://github.com/broadinstitute/terra-helmfile/blob/master/.github/actions/env-diff/action.yml) to comment on PRs with a diff of environment changes
-* **`argocd-custom-image`**: [Used by ArgoCD](https://github.com/broadinstitute/terra-helm-definitions/search?q=argocd-custom) to render Kubernetes manifests during ArgoCD deploys
 * **`jenkins-gke-deploy`**: [Used by Jenkins](https://github.com/broadinstitute/dsp-jenkins/search?q=jenkins-terra-gke-deploy) to trigger ArgoCD syncs during the Terra monolith release process
 * **`jenkins-helmfile-version-query`**: [Used by Jenkins](https://fc-jenkins.dsp-techops.broadinstitute.org/job/gke-service-update/) to verify that a version update has successfully merged.
 * **`render-action`**: [Used by terra-helmfile's render GitHub Action](https://github.com/broadinstitute/terra-helmfile/tree/master/.github/actions/render-action) to render manifests in different workflows.
+* **`argocd-custom-image`**: [Used by ArgoCD](https://github.com/broadinstitute/terra-helm-definitions/search?q=argocd-custom) to render Kubernetes manifests during ArgoCD deploys
 
-To update an image, open a PR and make any necessary changes. Once the PR is merged, update the tags of the images in the linked repositories.
+To update an image, open a PR and make any necessary changes. Everything except ArgoCD is pinned to the `main` tag, so the changes will be picked up automatically.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terra-helmfile-images
 
 [![codecov](https://codecov.io/gh/broadinstitute/terra-helmfile-images/branch/main/graph/badge.svg?token=QYQHL6UE6Y)](https://codecov.io/gh/broadinstitute/terra-helmfile-images)
-[![Go Report Card](https://goreportcard.com/badge/github.com/broadinstitute/terra-helmfile-images/tools](https://goreportcard.com/report/github.com/broadinstitute/terra-helmfile-images/tools)
+[![Go Report Card](https://goreportcard.com/badge/github.com/broadinstitute/terra-helmfile-images/tools)](https://goreportcard.com/report/github.com/broadinstitute/terra-helmfile-images/tools)
 
 This repository contains accessory tooling for the [terra-helmfile repo](https://github.com/broadinstitute/terra-helmfile). It includes:
 * Golang source code for various utilities for rendering manifests and publishing charts (see `tools/` subdirectory)

--- a/tools/cmd/render/main.go
+++ b/tools/cmd/render/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/broadinstitute/terra-helmfile-images/internal/render"
+	"github.com/broadinstitute/terra-helmfile-images/tools/internal/render"
 )
 
 func main() {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/broadinstitute/terra-helmfile-images
+module github.com/broadinstitute/terra-helmfile-images/tools
 
 go 1.16
 

--- a/tools/internal/render/cmd.go
+++ b/tools/internal/render/cmd.go
@@ -10,24 +10,22 @@ import (
 	"path/filepath"
 )
 
-/*
-This file handles CLI option parsing the render utility. It uses Cobra in accordance with the
-documentation here: https://github.com/spf13/cobra/blob/master/user_guide.md
-*/
+// This file handles CLI option parsing the render utility. It uses Cobra in accordance with the
+// documentation here: https://github.com/spf13/cobra/blob/master/user_guide.md
 
-/* Name of the Helmfile configuration repo */
-const ConfigRepoName = "terra-helmfile"
+// Name of the Helmfile configuration repo
+const configRepoName = "terra-helmfile"
 
-/* Environment variable used to set path to config repo clone */
-const ConfigRepoPathEnvVar = "TERRA_HELMFILE_PATH"
+// Environment variable used to set path to config repo clone
+const configRepoPathEnvVar = "TERRA_HELMFILE_PATH"
 
-/* Name of default output directory */
-const DefaultOutputDirName = "output"
+// Name of default output directory
+const defaultOutputDirName = "output"
 
-/* Default value for string CLI options */
+// Default value for string CLI options
 const optionUnset = ""
 
-/* Main method/entrypoint for the render tool. */
+// Execute is the main method/entrypoint for the render tool.
 func Execute() {
 	cobraCommand := newCobraCommand()
 
@@ -37,7 +35,7 @@ func Execute() {
 	}
 }
 
-/* Construct new Cobra command */
+// Construct new Cobra command
 func newCobraCommand() *cobra.Command {
 	options := &Options{}
 	cobraCommand := &cobra.Command{
@@ -133,10 +131,10 @@ func init() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 }
 
-/* Check Options for incompatible flags */
+// Check Options for incompatible flags
 func checkIncompatibleFlags(options *Options) error {
 	if isSet(options.App) && !isSet(options.Env) {
-		/* Not all environments include all apps, so require users to specify -e with -a */
+		// Not all environments include all apps, so require users to specify -e with -a
 		return fmt.Errorf("an environment must be specified with -e when an app is specified with -a")
 	}
 
@@ -171,9 +169,7 @@ func checkIncompatibleFlags(options *Options) error {
 	return nil
 }
 
-/*
-Normalize and validate path arguments.
-*/
+// Normalize and validate path arguments.
 func normalizePaths(options *Options) error {
 	if err := normalizeConfigRepoPath(options); err != nil {
 		return err
@@ -194,7 +190,7 @@ func normalizePaths(options *Options) error {
 	return normalizeOutputDir(options)
 }
 
-/* Adjust logging verbosity based on CLI options */
+// Adjust logging verbosity based on CLI options
 func adjustLoggingVerbosity(verbosity int) {
 	if verbosity > 1 {
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
@@ -203,23 +199,23 @@ func adjustLoggingVerbosity(verbosity int) {
 	}
 }
 
-/* Short-hand helper function indicating whether a string option was set by the user */
+// Short-hand helper function indicating whether a string option was set by the user
 func isSet(optionValue string) bool {
 	return optionValue != optionUnset
 }
 
-/* Validate config repo path and add to Options */
+// Validate config repo path and add to Options
 func normalizeConfigRepoPath(options *Options) error {
 	// We require configRepoPath to be set via environment variable
-	configRepoPath, defined := os.LookupEnv(ConfigRepoPathEnvVar)
+	configRepoPath, defined := os.LookupEnv(configRepoPathEnvVar)
 	if !defined {
-		return fmt.Errorf("please specify path to %s clone via the environment variable %s", ConfigRepoName, ConfigRepoPathEnvVar)
+		return fmt.Errorf("please specify path to %s clone via the environment variable %s", configRepoName, configRepoPathEnvVar)
 	}
 	options.ConfigRepoPath = configRepoPath
 	return nil
 }
 
-/* Validate chart dir, expand it, and add to Options */
+// Validate chart dir, expand it, and add to Options
 func normalizeChartDir(options *Options) error {
 	expanded, err := expandAndVerifyExists(options.ChartDir, "chart directory")
 	if err != nil {
@@ -229,10 +225,8 @@ func normalizeChartDir(options *Options) error {
 	return nil
 }
 
-/*
-For every --values-file arguments, expand to full path and verify it exists
-Then update Options to use the normalized paths
-*/
+// For every --values-file arguments, expand to full path and verify it exists
+// Then update Options to use the normalized paths
 func normalizeValuesFiles(options *Options) error {
 	var expandedValuesFiles []string
 
@@ -248,26 +242,24 @@ func normalizeValuesFiles(options *Options) error {
 	return nil
 }
 
-/*
-If an output dir was given, validate it. Else update Options with the default
-output directory, $CONFIG_REPO_PATH/output
-
-Note: This MUST be called after normalizeConfigRepoPath()
-*/
+// If an output dir was given, validate it. Else update Options with the default
+// output directory, $CONFIG_REPO_PATH/output
+//
+// Note: This MUST be called after normalizeConfigRepoPath()
 func normalizeOutputDir(options *Options) error {
 	if options.Stdout {
 		if isSet(options.OutputDir) {
 			return fmt.Errorf("--stdout cannot be used with -d/--output-dir")
-		} else {
-			// We're rendering to stdout, so no need to set up default output dir
-			return nil
 		}
+
+		// We're rendering to stdout, so no need to set up default output dir
+		return nil
 	}
 
 	// No output directory was given on the command-line, so set to default output
 	// directory $CONFIG_REPO_PATH/output
 	if !isSet(options.OutputDir) {
-		options.OutputDir = path.Join(options.ConfigRepoPath, DefaultOutputDirName)
+		options.OutputDir = path.Join(options.ConfigRepoPath, defaultOutputDirName)
 		log.Debug().Msgf("Using default output dir %s", options.OutputDir)
 	}
 
@@ -281,11 +273,9 @@ func normalizeOutputDir(options *Options) error {
 	return nil
 }
 
-/*
-Expand relative path to absolute.
-This is necessary for many arguments because Helmfile assumes paths
-are relative to helmfile.yaml and we want them to be relative to CWD.
-*/
+// Expand relative path to absolute.
+// This is necessary for many arguments because Helmfile assumes paths
+// are relative to helmfile.yaml and we want them to be relative to CWD.
 func expandAndVerifyExists(filePath string, description string) (*string, error) {
 	expanded, err := filepath.Abs(filePath)
 	if err != nil {

--- a/tools/internal/render/render.go
+++ b/tools/internal/render/render.go
@@ -12,41 +12,44 @@ import (
 	"strings"
 )
 
-/* Name of the `helmfile` binary */
+// Name of the `helmfile` binary
 const helmfileCommand = "helmfile"
 
-/* Subdirectory to search for environment config files */
-const envSubdir = "environments"
+// Subdirectory to search for environment config files
+const envDir = "environments"
 
-/* Options: Struct encapsulating options for a render */
+// Options encapsulates CLI options for a render
 type Options struct {
-	Env            string
-	App            string
-	ChartVersion   string
-	AppVersion     string
-	ChartDir       string
-	ValuesFiles    []string
-	ArgocdMode     bool
-	OutputDir      string
-	Stdout         bool
-	Verbose        int
-	ConfigRepoPath string
+	Env            string   // If supplied, render for a single environment instead of all
+	App            string   // If supplied, render for a single service instead of all
+	ChartVersion   string   // Optionally override chart version
+	AppVersion     string   // Optionally override app version
+	ChartDir       string   // When supplied, render chart from local directory instead of released version
+	ValuesFiles    []string // Optionally list of files for overriding chart values
+	ArgocdMode     bool     // If true, render ArgoCD manifests instead of application manifests
+	OutputDir      string   // Render to custom output directory intead of terra-helmfile/output
+	Stdout         bool     // Render to stdout instead of output directory
+	Verbose        int      // Invoke `helmfile` with verbose logging
+	ConfigRepoPath string   // Path to terra-helmfile repo clone
 }
 
+// Environment represents a Terra environment
 type Environment struct {
-	name string
-	base string
+	Name string // Environment name. Eg "dev", "alpha", "prod
+	Base string // Type of environment. Eg "live", "personal"
 }
 
+// Render generates manifests by invoking `helmfile` with the appropriate arguments
 type Render struct {
-	options          *Options               /* CLI options */
-	environments     map[string]Environment /* Collection of environments defined in the config repo, keyed by env name */
-	helmfileLogLevel string                 /* --log-level argument to pass to `helmfile` command */
+	options          *Options               // CLI options
+	environments     map[string]Environment // Collection of environments defined in the config repo, keyed by env Name
+	helmfileLogLevel string                 // --log-level argument to pass to `helmfile` command
 }
 
-/* ShellRunner object used to execute commands. Replaced with a mock in tests */
+// Global/package-level variable, used for executing commands. Replaced with a mock in tests.
 var shellRunner ShellRunner = &RealRunner{}
 
+// NewRender is a constructor
 func NewRender(options *Options) (*Render, error) {
 	render := new(Render)
 	render.options = options
@@ -65,7 +68,7 @@ func NewRender(options *Options) (*Render, error) {
 	return render, nil
 }
 
-/* Clean output directory */
+// CleanOutputDirectory removes any old files from output directory
 func (r *Render) CleanOutputDirectory() error {
 	if r.options.Stdout {
 		// No need to clean output directory if we're rendering to stdout
@@ -101,13 +104,13 @@ func (r *Render) CleanOutputDirectory() error {
 	return nil
 }
 
-/* Update Helm repos */
+// HelmUpdate updates Helm repos
 func (r *Render) HelmUpdate() error {
 	log.Debug().Msg("Updating Helm repos...")
 	return r.runHelmfile("--allow-no-matching-release", "repos")
 }
 
-/* Render manifests */
+// RenderAll renders manifests based on supplied arguments
 func (r *Render) RenderAll() error {
 	targetEnvs, err := r.getTargetEnvs()
 	if err != nil {
@@ -126,13 +129,13 @@ func (r *Render) RenderAll() error {
 	return normalizeRenderDirectories(r.options.OutputDir)
 }
 
-/* Scan through environments/ subdirectory and build a slice of defined environments */
+// loadEnvironments scans through the environments/ subdirectory and build a slice of defined environments
 func loadEnvironments(configRepoPath string) (map[string]Environment, error) {
 	environments := make(map[string]Environment)
 
-	envDir := path.Join(configRepoPath, envSubdir)
+	envDir := path.Join(configRepoPath, envDir)
 	if _, err := os.Stat(envDir); err != nil {
-		return nil, fmt.Errorf("environments subdirectory %s does not exist in %s, is it a %s clone?", envSubdir, configRepoPath, ConfigRepoName)
+		return nil, fmt.Errorf("environments subdirectory %s does not exist in %s, is it a %s clone?", envDir, configRepoPath, configRepoName)
 	}
 
 	matches, err := filepath.Glob(path.Join(envDir, "*", "*.yaml"))
@@ -141,19 +144,20 @@ func loadEnvironments(configRepoPath string) (map[string]Environment, error) {
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no environments found in %s, is it a %s clone?", configRepoPath, ConfigRepoName)
+		return nil, fmt.Errorf("no environments found in %s, is it a %s clone?", configRepoPath, configRepoName)
 	}
 
 	for _, filename := range matches {
 		env := Environment{}
-		env.base = path.Base(path.Dir(filename))
-		env.name = strings.TrimSuffix(path.Base(filename), ".yaml")
-		environments[env.name] = env
+		env.Base = path.Base(path.Dir(filename))
+		env.Name = strings.TrimSuffix(path.Base(filename), ".yaml")
+		environments[env.Name] = env
 	}
 
 	return environments, nil
 }
 
+// getTargetEnvs returns the set of target environments to render manifests for
 func (r *Render) getTargetEnvs() ([]Environment, error) {
 	if isSet(r.options.Env) {
 		// User wants to render for a specific environment
@@ -177,12 +181,12 @@ func (r *Render) getTargetEnvs() ([]Environment, error) {
 }
 
 func (r *Render) renderSingleEnvironment(env Environment) error {
-	log.Info().Msgf("Rendering manifests for %s", env.name)
+	log.Info().Msgf("Rendering manifests for %s", env.Name)
 
 	var args []string
 
 	// Append global Helmfile options
-	args = append(args, "-e", env.name)
+	args = append(args, "-e", env.Name)
 
 	selectors := r.getSelectors()
 	if len(selectors) != 0 {
@@ -211,7 +215,7 @@ func (r *Render) renderSingleEnvironment(env Environment) error {
 		// Expand output dir to absolute path, because Helmfile assumes paths
 		// are relative to helmfile.yaml and we want to be relative to CWD
 		// filepath.Abs()
-		args = append(args, fmt.Sprintf("--output-dir=%s/%s", r.options.OutputDir, env.name))
+		args = append(args, fmt.Sprintf("--output-dir=%s/%s", r.options.OutputDir, env.Name))
 	}
 
 	return r.runHelmfile(args...)
@@ -231,7 +235,7 @@ func (r *Render) runHelmfile(args ...string) error {
 	return shellRunner.Run(cmd)
 }
 
-/* Return map of state values that should be set on the command-line, given user-supplied options */
+// getStateValues returns a map of state values that should be set on the command-line, given user-supplied options
 func (r *Render) getStateValues() map[string]string {
 	stateValues := make(map[string]string)
 
@@ -251,7 +255,7 @@ func (r *Render) getStateValues() map[string]string {
 	return stateValues
 }
 
-/* Return map of Helmfile selectors that should be set on the command-line, given user-supplied options */
+// getSelectors returns a map of Helmfile selectors that should be set on the command-line, given user-supplied options
 func (r *Render) getSelectors() map[string]string {
 	selectors := make(map[string]string)
 	selectors["group"] = "terra"
@@ -268,16 +272,14 @@ func (r *Render) getSelectors() map[string]string {
 	return selectors
 }
 
-/*
-Convert auto-generated template directory names like
-  helmfile-b47efc70-workspacemanager
-into
-  workspacemanager
-so that diff -r can be run on two sets of rendered templates.
-
-We enforce that all release names in an environment are unique,
-so this should not cause conflicts.
-*/
+// normalizeRenderDirectories converts auto-generated template directory names like
+//   helmfile-b47efc70-workspacemanager
+// into
+//   workspacemanager
+// so that diff -r can be run on two sets of rendered templates.
+//
+// We enforce that all release names in an environment are unique,
+// so this should not cause conflicts.
 func normalizeRenderDirectories(outputDir string) error {
 	matches, err := filepath.Glob(path.Join(outputDir, "*", "helmfile-*"))
 	if err != nil {
@@ -301,23 +303,18 @@ func normalizeRenderDirectories(outputDir string) error {
 	return nil
 }
 
-/*
-Sort environments lexicographically by base, and then by name
-*/
+// sortEnvironments sorts environments lexicographically by base, and then by name
 func sortEnvironments(envs []Environment) {
 	sort.Slice(envs, func(i int, j int) bool {
-		if envs[i].base == envs[j].base {
-			return envs[i].name < envs[j].name
-		} else {
-			return envs[i].base < envs[j].base
+		if envs[i].Base == envs[j].Base {
+			return envs[i].Name < envs[j].Name
 		}
+		return envs[i].Base < envs[j].Base
 	})
 }
 
-/*
-Join map[string]string to string containing comma-separated key-value pairs.
-Eg. { "a": "b", "c": "d" } -> "a=b,c=d"
-*/
+// joinKeyValuePairs joins map[string]string to string containing comma-separated key-value pairs.
+// Eg. { "a": "b", "c": "d" } -> "a=b,c=d"
 func joinKeyValuePairs(pairs map[string]string) string {
 	var tokens []string
 	for k, v := range pairs {

--- a/tools/internal/render/render_test.go
+++ b/tools/internal/render/render_test.go
@@ -12,16 +12,16 @@ import (
 	"testing"
 )
 
-/* This file contains an integration test for the render utility */
+// This file contains an integration test for the render utility
 
-/* Fake environments, mocked for integration testing */
+// Fake environments, mocked for integration testing
 var fakeEnvironments = []Environment{
-	{name: "dev", base: "live"},
-	{name: "alpha", base: "live"},
-	{name: "jdoe", base: "personal"},
+	{Name: "dev", Base: "live"},
+	{Name: "alpha", Base: "live"},
+	{Name: "jdoe", Base: "personal"},
 }
 
-/* Struct for tracking global state that is mocked when a test executes and restored/cleaned up after */
+// Struct for tracking global state that is mocked when a test executes and restored/cleaned up after
 type TestState struct {
 	mockRunner             *MockRunner  // mock ShellRunner, reset before every test case
 	mockConfigRepoPath     string       // mock terra-helmfile, created once before all test cases
@@ -40,22 +40,21 @@ type TestCase struct {
 	setup            func() error      // Optional hook for extra setup
 }
 
-/* Used in MockRunner to verify expected commands have been called */
+// Used in MockRunner to verify expected commands have been called
 type ExpectedCommand struct {
 	Command   Command // Expected Command
 	MockError error   // Optional error to return (for faking an error running the command)
 }
 
-/* MockRunner stores an ordered list (slice) of expected commands */
+// MockRunner stores an ordered list (slice) of expected commands
 type MockRunner struct {
 	expectedCommands []ExpectedCommand // Ordered list of expected commands
 }
 
-/*
-Mock implementation of ShellCommand#Run
-
-Instead of executing the command, compare it to the runner's list of expected commands, throwing an error on mismatch
-*/
+// Mock implementation of ShellCommand
+//
+// Instead of executing the command, compare it to the runner's list of expected commands,
+// throwing an error on mismatch
 func (m *MockRunner) Run(cmd Command) error {
 	if len(m.expectedCommands) == 0 {
 		return fmt.Errorf("MockRunner: Received unexpected command %v", cmd)
@@ -71,15 +70,13 @@ func (m *MockRunner) Run(cmd Command) error {
 	return expected.MockError
 }
 
-/*
-A table-driven integration test for the render tool.
-
-Given a list of CLI arguments to the render command, the test verifies
-that the correct underlying `helmfile` command(s) are run.
-
-Reference:
-https://gianarb.it/blog/golang-mockmania-cli-command-with-cobra
-*/
+// A table-driven integration test for the render tool.
+//
+// Given a list of CLI arguments to the render command, the test verifies
+// that the correct underlying `helmfile` command(s) are run.
+//
+// Reference:
+// https://gianarb.it/blog/golang-mockmania-cli-command-with-cobra
 func TestRender(t *testing.T) {
 	// Set up mocked global state before tests run
 	ts, err := setup()
@@ -346,7 +343,7 @@ func TestRender(t *testing.T) {
 	}
 }
 
-/* Integration test does not exercise normalizeRenderDirectories(), so add a unit test here */
+// Integration test does not exercise normalizeRenderDirectories(), so add a unit test here
 func TestNormalizeRenderDirectories(t *testing.T) {
 	t.Run("test directories are normalized", func(t *testing.T) {
 		// Create tmpdir
@@ -394,19 +391,15 @@ func TestNormalizeRenderDirectories(t *testing.T) {
 	})
 }
 
-/*
-Convenience function to generate tokenized argument list from format string w/ args
-
-Eg. args("-e   %s", "dev") -> []string{"-e", "dev"}
-*/
+// Convenience function to generate tokenized argument list from format string w/ args
+//
+// Eg. args("-e   %s", "dev") -> []string{"-e", "dev"}
 func args(format string, a ...interface{}) []string {
 	formatted := fmt.Sprintf(format, a...)
 	return strings.Fields(formatted)
 }
 
-/*
-Convenience function to return current working directory
-*/
+// Convenience function to return current working directory
 func cwd() string {
 	dir, err := os.Getwd()
 	if err != nil {
@@ -415,13 +408,10 @@ func cwd() string {
 	return dir
 }
 
-/*
-Convenience function to create a successful/non-erroring ExpectedCommand, given
-a format string _for_ the command.
-
-Eg. cmd("helmfile -e %s template", "alpha")
-
-*/
+// Convenience function to create a successful/non-erroring ExpectedCommand, given
+// a format string _for_ the command.
+//
+// Eg. cmd("helmfile -e %s template", "alpha")
 func (ts *TestState) cmd(format string, a ...interface{}) ExpectedCommand {
 	tokens := args(format, a...)
 
@@ -434,20 +424,17 @@ func (ts *TestState) cmd(format string, a ...interface{}) ExpectedCommand {
 	}
 }
 
-/*
-Convenience function to create a failing ExpectedCommand with an error
-a format string _for_ the command.
-
-Eg. cmd("helmfile -e %s template", "alpha")
-
-*/
+// Convenience function to create a failing ExpectedCommand with an error
+// a format string _for_ the command.
+//
+// Eg. cmd("helmfile -e %s template", "alpha")
 func (ts *TestState) failCmd(err string, format string, a ...interface{}) ExpectedCommand {
 	expectedCommand := ts.cmd(format, a...)
 	expectedCommand.MockError = errors.New(err)
 	return expectedCommand
 }
 
-/* Per-test case setup */
+// Per-test case setup
 func (ts *TestState) setupTestCase(tc TestCase) error {
 	// Delete and re-create scratch directory
 	if err := os.RemoveAll(ts.scratchDir); err != nil {
@@ -470,17 +457,17 @@ func (ts *TestState) setupTestCase(tc TestCase) error {
 	return nil
 }
 
-/* One-time setup, run before all TestRender test cases */
+// One-time setup, run before all TestRender test cases
 func setup() (*TestState, error) {
 	// Create a mock config repo clone in a tmp dir
-	originalConfigRepoPath := os.Getenv(ConfigRepoPathEnvVar)
+	originalConfigRepoPath := os.Getenv(configRepoPathEnvVar)
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "render-test")
 	if err != nil {
 		return nil, err
 	}
 
-	mockConfigRepoPath := path.Join(tmpDir, ConfigRepoName)
+	mockConfigRepoPath := path.Join(tmpDir, configRepoName)
 	err = os.MkdirAll(mockConfigRepoPath, 0755)
 	if err != nil {
 		return nil, err
@@ -494,7 +481,7 @@ func setup() (*TestState, error) {
 
 	// Overwrite TERRA_HELMFILE_PATH env var value with path to our fake config repo clone
 	// Note: When Golang 1.17 is released we can use t.Setenv() instead https://github.com/golang/go/issues/41260
-	err = os.Setenv(ConfigRepoPathEnvVar, mockConfigRepoPath)
+	err = os.Setenv(configRepoPathEnvVar, mockConfigRepoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -525,14 +512,14 @@ func setup() (*TestState, error) {
 	}, nil
 }
 
-/* One-time cleanup, run after all TestCases have run */
+// One-time cleanup, run after all TestCases have run
 func cleanup(state *TestState) error {
 	// Restore original ShellRunner
 	shellRunner = *(state.originalRunner)
 
 	// Restore original config repo path
 	// When Golang 1.17 is released we can use t.Setenv() instead https://github.com/golang/go/issues/41260
-	err := os.Setenv(ConfigRepoPathEnvVar, state.originalConfigRepoPath)
+	err := os.Setenv(configRepoPathEnvVar, state.originalConfigRepoPath)
 	if err != nil {
 		return err
 	}
@@ -541,11 +528,11 @@ func cleanup(state *TestState) error {
 	return os.RemoveAll(state.rootDir)
 }
 
-/* Create fake environment files like `environments/live/alpha.yaml` in mock config dir */
+// Create fake environment files like `environments/live/alpha.yaml` in mock config dir
 func createFakeEnvironmentFiles(mockConfigRepoPath string, envs []Environment) error {
 	for _, env := range envs {
-		baseDir := path.Join(mockConfigRepoPath, envSubdir, env.base)
-		envFile := path.Join(baseDir, fmt.Sprintf("%s.yaml", env.name))
+		baseDir := path.Join(mockConfigRepoPath, envDir, env.Base)
+		envFile := path.Join(baseDir, fmt.Sprintf("%s.yaml", env.Name))
 
 		if err := createFile(envFile, "# Fake env file for testing"); err != nil {
 			return err
@@ -555,7 +542,7 @@ func createFakeEnvironmentFiles(mockConfigRepoPath string, envs []Environment) e
 	return nil
 }
 
-/* Convenience function for creating multiple fake files in scratch directory */
+// Convenience function for creating multiple fake files in scratch directory
 func (ts *TestState) createScratchFiles(content string, filenames ...string) error {
 	for _, f := range filenames {
 		if err := ts.createScratchFile(f, content); err != nil {
@@ -565,12 +552,12 @@ func (ts *TestState) createScratchFiles(content string, filenames ...string) err
 	return nil
 }
 
-/* Convenience function for creating a fake file in scratch directory */
+// Convenience function for creating a fake file in scratch directory
 func (ts *TestState) createScratchFile(filename string, content string) error {
 	return createFile(path.Join(ts.scratchDir, filename), content)
 }
 
-/* Convenience function for creating a fake file */
+// Convenience function for creating a fake file
 func createFile(filepath string, content string) error {
 	dir := path.Dir(filepath)
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/tools/internal/render/shell.go
+++ b/tools/internal/render/shell.go
@@ -19,7 +19,7 @@ type ShellRunner interface {
 
 type ShellError struct {
 	Command Command
-	Err error
+	Err     error
 }
 
 func (e *ShellError) Error() string {

--- a/tools/internal/render/shell.go
+++ b/tools/internal/render/shell.go
@@ -8,52 +8,59 @@ import (
 	"strings"
 )
 
-/*
-Wrapper around exec.Command to support interface-based mocking for unit testing
-
-https://joshrendek.com/2014/06/go-lang-mocking-exec-dot-command-using-interfaces/
-*/
+//
+// ShellRunner is an interface for running shell commands. It exists to
+// support mocking shell commands in unit tests.
+//
+// https://joshrendek.com/2014/06/go-lang-mocking-exec-dot-command-using-interfaces/
+//
 type ShellRunner interface {
 	Run(cmd Command) error
 }
 
+// ShellError represents an error encountered running a shel command
 type ShellError struct {
 	Command Command
 	Err     error
 }
 
+// Error generates a user-friendly error message for failed shell commands
 func (e *ShellError) Error() string {
 	cmd := e.Command.PrettyFormat()
 	if exitErr, ok := e.Err.(*exec.ExitError); ok {
 		// Command exited non-zero
-		return fmt.Sprintf("Command exited with status %d: %q", exitErr.ExitCode(), cmd)
-	} else {
-		// Command failed to start for some reason
-		return fmt.Sprintf("Command %q failed to start: %v", cmd, e.Err)
+		return fmt.Sprintf("Command %q exited with status %d", cmd, exitErr.ExitCode())
 	}
+
+	// Command failed to start for some reason
+	return fmt.Sprintf("Command %q failed to start: %v", cmd, e.Err)
 }
 
+// Command encapsulates a shell command
 type Command struct {
-	Prog string
-	Args []string
-	Dir  string
+	Prog string   // Main CLI program to execute
+	Args []string // Arguments to pass to program
+	Dir  string   // Directory where command should be run
 }
 
-/* Convert command into simple string for easy inspection. Eg.
-&Command{
-  Prog: []string{"echo"},
-  Args: []string{"foo", "bar", "baz"},
-  Dir:  "/tmp",
-}
-->
-"echo foo bar baz"
-*/
+// PrettyFormat converts command into a simple string for easy inspection. Eg.
+// &Command{
+//   Prog: []string{"echo"},
+//   Args: []string{"foo", "bar", "baz"},
+//   Dir:  "/tmp",
+// }
+// ->
+// "echo foo bar baz"
 func (c *Command) PrettyFormat() string {
+	// TODO shellquote arguments for better readability
 	return strings.Join(append([]string{c.Prog}, c.Args...), " ")
 }
 
+// RealRunner is an implementation of the Runner API that actually executes shell commands
+// (contrast with MockRunner)
 type RealRunner struct{}
 
+// Run runs a Command, returning an error if the command exits non-zero
 func (r *RealRunner) Run(cmd Command) error {
 	execCmd := exec.Command(cmd.Prog, cmd.Args...)
 	execCmd.Dir = cmd.Dir

--- a/tools/internal/render/shell_test.go
+++ b/tools/internal/render/shell_test.go
@@ -1,0 +1,79 @@
+package render
+
+import (
+	"os"
+	"path"
+	"regexp"
+	"testing"
+)
+
+func TestRunSuccess(t *testing.T) {
+	// Create tmp dir and remove it
+	tmpdir, err := os.MkdirTemp("", "shell-test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	runner := RealRunner{}
+	cmd := Command{}
+	cmd.Prog = "mkdir"
+	cmd.Args = []string{ "test-dir-1" }
+	cmd.Dir = tmpdir
+
+	err = runner.Run(cmd)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that the command was run and created the directory
+	testDir := path.Join(tmpdir, "test-dir-1")
+	f, err := os.Stat(testDir)
+	if err != nil {
+		t.Errorf("testDir does not exist: %v", err)
+	}
+	if !f.IsDir() {
+		t.Errorf("testDir is not directory: %v", f)
+	}
+}
+
+func TestRunFailed(t *testing.T) {
+	runner := RealRunner{}
+	cmd := Command{}
+	cmd.Prog = "sh"
+	cmd.Args = []string{ "-c", "exit 42" }
+	cmd.Dir = ""
+
+	err := runner.Run(cmd)
+	if err == nil {
+		t.Errorf("Expected error when running command: %v", cmd)
+	}
+	shellErr, ok := err.(*ShellError)
+	if !ok {
+		t.Errorf("Expected ShellError, got: %v", err)
+	}
+	if !regexp.MustCompile("Command \"sh -c exit 42\" exited with status 42").MatchString(shellErr.Error()) {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+func TestRunError(t *testing.T) {
+	runner := RealRunner{}
+	cmd := Command{}
+	cmd.Prog = "echo"
+	cmd.Args = []string{ "a", "b" }
+	cmd.Dir = "/this-file-does-not-exist-398u48"
+
+	err := runner.Run(cmd)
+	if err == nil {
+		t.Errorf("Expected error when running command: %v", cmd)
+	}
+	shellErr, ok := err.(*ShellError)
+	if !ok {
+		t.Errorf("Expected ShellError, got: %v", err)
+	}
+	if !regexp.MustCompile("Command \"echo a b\" failed to start").MatchString(shellErr.Error()) {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+


### PR DESCRIPTION
* Make it possible to supply custom values file to `helmfile template` via a new `render` flag, `--values-file`.
* Add some test coverage for ShellRunner
* Cleanup:
  * Add license
  * Add buttons to README, shamelessly copied from Sherlock
  * Address Go report card findings (mostly formatting issues)
  
(This PR mixes formatting and feature changes... apologies to reviewers!)