### PR TITLE
DDO-1410 Fix argo plugins for compatibility with new render tool

### DIFF
--- a/images/argocd-custom-image/terra-helmfile-app/terra-helmfile-app.sh
+++ b/images/argocd-custom-image/terra-helmfile-app/terra-helmfile-app.sh
@@ -32,6 +32,7 @@ elif [[ "$1" == 'generate' ]]; then
     args+=( --chart-version "${TERRA_CHART_VERSION}" )
   fi
 
+  export TERRA_HELMFILE_PATH=$( pwd )
   render -e "${TERRA_ENV}" -a "${TERRA_APP}" "${args[@]}"
 else
   echo "Usage: ${0} (init|generate)" >&2

--- a/images/argocd-custom-image/terra-helmfile-app/terra-helmfile-app.sh
+++ b/images/argocd-custom-image/terra-helmfile-app/terra-helmfile-app.sh
@@ -33,7 +33,7 @@ elif [[ "$1" == 'generate' ]]; then
   fi
 
   export TERRA_HELMFILE_PATH=$( pwd )
-  render -e "${TERRA_ENV}" -a "${TERRA_APP}" "${args[@]}"
+  render --stdout -e "${TERRA_ENV}" -a "${TERRA_APP}" "${args[@]}"
 else
   echo "Usage: ${0} (init|generate)" >&2
   exit 1

--- a/images/argocd-custom-image/terra-helmfile-argocd/terra-helmfile-argocd.sh
+++ b/images/argocd-custom-image/terra-helmfile-argocd/terra-helmfile-argocd.sh
@@ -8,11 +8,13 @@
 set -eo pipefail
 set -x
 
+
 if [[ "$1" == 'init' ]]; then
   : # Nothing to do
 elif [[ "$1" == 'generate' ]]; then
   # Delegate to render script
-  ./bin/render --argocd
+  export TERRA_HELMFILE_PATH=$( pwd )
+  render --argocd
 else
   echo "Usage: ${0} (init|generate)" >&2
   exit 1

--- a/images/argocd-custom-image/terra-helmfile-argocd/terra-helmfile-argocd.sh
+++ b/images/argocd-custom-image/terra-helmfile-argocd/terra-helmfile-argocd.sh
@@ -14,7 +14,7 @@ if [[ "$1" == 'init' ]]; then
 elif [[ "$1" == 'generate' ]]; then
   # Delegate to render script
   export TERRA_HELMFILE_PATH=$( pwd )
-  render --argocd
+  render --stdout --argocd
 else
   echo "Usage: ${0} (init|generate)" >&2
   exit 1


### PR DESCRIPTION
This merge broke the terra-app-generator job: https://github.com/broadinstitute/terra-helmfile/pull/1384

I forgot to update our ArgoCD plugin scripts for compatibility with CLI changes, in particular that the rewritten `render` script needs `--stdout` in order to render stdout instead of the filesystem (it used to render to stdout by default).

Whoops! This PR should fix it.