### PR TITLE
DDO-1433 Add terra-helmfile-app plugin to ArgoCD image

### DIFF
--- a/images/argocd-custom-image/Dockerfile
+++ b/images/argocd-custom-image/Dockerfile
@@ -87,6 +87,11 @@ ENV PATH="/custom-tools/helm-values:${PATH}"
 COPY helmfile /custom-tools/helmfile
 ENV PATH="/custom-tools/helmfile:${PATH}"
 
+## `terra-helmfile-app` plugin
+# Wrapper script for rendering application manifests from terra-helmfile repo
+COPY terra-helmfile-app /custom-tools/terra-helmfile-app
+ENV PATH="/custom-tools/terra-helmfile-app:${PATH}"
+
 ## `terra-helmfile-argocd` plugin
 # Wrapper script for generating ArgoCD resources from terra-helmfile repo
 COPY terra-helmfile-argocd /custom-tools/terra-helmfile-argocd


### PR DESCRIPTION
**Bugfix**: Terra apps are still using the old `helmfile` plugin, which runs `helmfile` instead of `render`