### PR TITLE
DDO-1274 Build new images for the latest ArgoCD 2.0.x release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,7 +129,7 @@ jobs:
           - "jenkins-helmfile-version-query"
           - "render-action"
     env:
-      ARGOCD_VERSION: "1.7.7"
+      ARGOCD_VERSION: "2.0.5"
       VAULT_VERSION: "1.1.0"
     steps:
       - name: Checkout code


### PR DESCRIPTION
Image updates for ArgoCD 2.0.5.

Related: https://github.com/broadinstitute/terra-helm/pull/476