### PR TITLE
DDO-1590 Add support for rendering multiple targets in parallel

### DIFF
--- a/images/render-action/entrypoint.sh
+++ b/images/render-action/entrypoint.sh
@@ -23,6 +23,11 @@ if [[ -n "${TERRA_ENV}" ]]; then
   env="-e ${TERRA_ENV}"
 fi
 
+parallelWorkers=
+if [[ -n "${PARALLEL_WORKERS}" ]]; then
+  parallelWorkers="--parallel-workers ${PARALLEL_WORKERS}"
+fi
+
 set -x
 echo "Running render in $( pwd )"
-/tools/bin/render --output-dir="${OUTPUT_DIR}" $env $argocd
+/tools/bin/render $parallelWorkers --output-dir="${OUTPUT_DIR}" $env $argocd

--- a/tools/internal/render/cli/cli_test.go
+++ b/tools/internal/render/cli/cli_test.go
@@ -136,6 +136,11 @@ func TestArgumentParsing(t *testing.T) {
 			expectedError: regexp.MustCompile("--stdout cannot be used with --output-dir"),
 		},
 		{
+			description:   "--parallel-workers and --stdout incompatible",
+			arguments:     args("--parallel-workers 10 --stdout"),
+			expectedError: regexp.MustCompile("--parallel-workers cannot be used with --stdout"),
+		},
+		{
 			description:   "--cluster and --app-version incompatible",
 			arguments:     args("--cluster terra-perf -r leonardo --app-version=0.0.1"),
 			expectedError: regexp.MustCompile("--app-version cannot be used for cluster releases"),
@@ -224,6 +229,14 @@ func TestArgumentParsing(t *testing.T) {
 			arguments: args("-v -v"),
 			setupFn: func(tc *testConfig) error {
 				tc.expected.renderOptions.Verbosity = 2
+				return nil
+			},
+		},
+		{
+			description: "--parallel-workers should set workers",
+			arguments: args("--parallel-workers 32"),
+			setupFn: func(tc *testConfig) error {
+				tc.expected.renderOptions.ParallelWorkers = 32
 				return nil
 			},
 		},
@@ -342,6 +355,9 @@ func TestArgumentParsing(t *testing.T) {
 			// add path to expectedAttrs objects so that equals() comparisons succeed
 			expected.renderOptions.ConfigRepoPath = configRepoPath
 			expected.renderOptions.OutputDir = path.Join(configRepoPath, "output")
+
+			// set other defaults
+			expected.renderOptions.ParallelWorkers = 1
 
 			// set cli args
 			cli.setArgs(testCase.arguments)

--- a/tools/internal/render/cli/integration_test.go
+++ b/tools/internal/render/cli/integration_test.go
@@ -96,6 +96,19 @@ func TestRender(t *testing.T) {
 			},
 		},
 		{
+			description: "--parallel-workers=10 should render without errors",
+			arguments:   args("--parallel-workers=10"),
+			setupMocks: func(ts *TestState) error {
+				ts.expectHelmfileUpdateCmd()
+				ts.expectHelmfileCmd(tdrStagingCluster, "--log-level=info --selector=mode=release template --skip-deps --output-dir=%s/output/tdr-staging", ts.mockConfigRepoPath)
+				ts.expectHelmfileCmd(perfCluster, "--log-level=info --selector=mode=release template --skip-deps --output-dir=%s/output/terra-perf", ts.mockConfigRepoPath)
+				ts.expectHelmfileCmd(alphaEnv, "--log-level=info --selector=mode=release template --skip-deps --output-dir=%s/output/alpha", ts.mockConfigRepoPath)
+				ts.expectHelmfileCmd(devEnv, " --log-level=info --selector=mode=release template --skip-deps --output-dir=%s/output/dev", ts.mockConfigRepoPath)
+				ts.expectHelmfileCmd(jdoeEnv, "--log-level=info --selector=mode=release template --skip-deps --output-dir=%s/output/jdoe", ts.mockConfigRepoPath)
+				return nil
+			},
+		},
+		{
 			description: "--argocd without -e or -a should render Argo manifests for all targets",
 			arguments:   args("--argocd"),
 			setupMocks: func(ts *TestState) error {
@@ -510,7 +523,7 @@ func setup(t *testing.T) (*TestState, error) {
 	scratchDir := path.Join(tmpDir, "scratch")
 
 	// Create a mock runner for executing shell commands
-	mockRunner := shellmock.DefaultMockRunner()
+	mockRunner := shellmock.NewMockRunner(shellmock.Options{VerifyOrder: false})
 	mockRunner.Test(t)
 
 	// Replace real shell runner with mock runner; will be restored by cleanup() when this test completes


### PR DESCRIPTION
### Changes
* `cli`: Add new flag, --parallel-workers, defaulting to 1
* `render`: Rewrite renderAll function to render targets in parallel using worker pool pattern
* `render-action`: Add support for setting number of parallel workers via `$PARALLEL_WORKERS` env var
* `shellmock`: Synchronize `Run` calls, because testify mock isn't thread-safe