### PR TITLE
[DDO-1994] Put GCE instance OIDC JWT in header for IAP

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Auth to GCP
         uses: google-github-actions/auth@v0
         with:
-          service_account_key: ${{ secrets.GCP_PUBLISH_KEY_B64 }}
+          credentials_json: ${{ secrets.GCP_PUBLISH_KEY_B64 }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,11 +79,12 @@ jobs:
           echo "::set-output name=tagged::${NAME}:${{ steps.tags.outputs.long }}"
 
       - name: Auth to GCP
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/auth@v0
         with:
-          version: '345.0.0'
-          service_account_email: ${{ secrets.GCP_PUBLISH_EMAIL }}
-          service_account_key:   ${{ secrets.GCP_PUBLISH_KEY_B64 }}
+          service_account_key: ${{ secrets.GCP_PUBLISH_KEY_B64 }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
 
       - name: Explicitly auth Docker for Artifact Registry
         run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet


### PR DESCRIPTION
Like [this PR for WSM's sync action](https://github.com/DataBiosphere/terra-workspace-manager/pull/613/files), but in GCE-land where we eschew Workload Identity in favor of the default SA already present on all the (prod and non-prod) Jenkins GCE instances.

I already allowed that SA through IAP [here](https://github.com/broadinstitute/terraform-ap-deployments/pull/599) and I've tested this manually against the currently-behind-IAP Sherlock.

GCE lets code running on the instance get an OIDC JWT for the SA it is running as. If we set the audience (JWT `aud` claim) to IAP's client ID and get the 'full' token (for the JWT `email` claim), the response is perfectly valid for IAP.

My approach here is "just do the simple thing because we're going to replace this". We'll let IAP care about actually validating the JWT when we enable it (since I've already been able to fairly thoroughly test this, I think it is actually more brittle to add a bunch of fail-fast logic when we're piping the output of one Google API into another).

As I've seen with WSM, Argo couldn't care less about the proxy auth header, so we can apply this before we turn IAP on. I do think I'll try a deploy off of a build of this image to be sure that it is alright before merging.