### PR TITLE
DDO-2500 Changes for ArgoCD 2.5.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
           - "jenkins-gke-deploy"
           - "jenkins-helmfile-version-query"
     env:
-      ARGOCD_VERSION: "2.2.5"
+      ARGOCD_VERSION: "2.5.3"
       VAULT_VERSION: "1.1.0"
     steps:
       - name: Checkout code

--- a/images/argocd-custom-image/Dockerfile
+++ b/images/argocd-custom-image/Dockerfile
@@ -18,6 +18,7 @@ RUN echo "ArgoCD version: ${argocd_version}"
 USER root
 
 # Ruby and curl are needed for configure.rb / `legacy-configs` plugin
+# Python3 is needed for Google Cloud SDK
 RUN apt-get update && \
     apt-get install -y \
         python3 \

--- a/images/argocd-custom-image/Dockerfile
+++ b/images/argocd-custom-image/Dockerfile
@@ -37,6 +37,9 @@ ENV PATH="/custom-tools/bin:${PATH}"
 
 # Switch back to non-root user
 # (this is set in the ArgoCD Dockerfile https://github.com/argoproj/argo-cd/blob/d2699888d125f73848b102f4addbd99c0253702d/Dockerfile#LL78)
+# We use the numeric id to sidestep
+# "Error: container has runAsNonRoot and image has non-numeric user (argocd), cannot verify user is non-root"
+# on Kubernetes
 USER $ARGOCD_USER_ID
 
 ## Install dependencies for the `legacy-configs` plugin

--- a/images/argocd-custom-image/Dockerfile
+++ b/images/argocd-custom-image/Dockerfile
@@ -20,6 +20,7 @@ USER root
 # Ruby and curl are needed for configure.rb / `legacy-configs` plugin
 RUN apt-get update && \
     apt-get install -y \
+        python3 \
         wget \
         curl \
         jq \

--- a/images/argocd-custom-image/Dockerfile
+++ b/images/argocd-custom-image/Dockerfile
@@ -36,7 +36,8 @@ RUN mkdir -p /custom-tools/bin && chown -R argocd:argocd /custom-tools
 ENV PATH="/custom-tools/bin:${PATH}"
 
 # Switch back to non-root user
-USER argocd
+# (this is set in the ArgoCD Dockerfile https://github.com/argoproj/argo-cd/blob/d2699888d125f73848b102f4addbd99c0253702d/Dockerfile#LL78)
+USER $ARGOCD_USER_ID
 
 ## Install dependencies for the `legacy-configs` plugin
 # (aka the firecloud-develop ctmpl rendering process)

--- a/images/argocd-custom-image/legacy-configs/legacy-configs.sh
+++ b/images/argocd-custom-image/legacy-configs/legacy-configs.sh
@@ -3,6 +3,15 @@
 # An ArgoCD application for rendering application configs from firecloud-develop.
 set -eo pipefail
 
+#
+# Fix for https://argocd-vault-plugin.readthedocs.io/en/stable/config/#argocd-240-environment-variable-prefix
+# Rewrite all environment variables prefixed with ARGOCD_ENV_<NAME> as <NAME>
+#
+tmpfile="/tmp/.legacy-configs.env.$$"
+trap "rm -f ${tmpfile}" EXIT
+printenv | grep "^ARGOCD_ENV_" | sed 's/^ARGOCD_ENV_/export /g' > "${tmpfile}"
+. "${tmpfile}"
+
 ## Required arguments
 : "${ENV?Env variable ENV is missing but required. Eg. \"dev\"}"
 : "${APP_NAME?Env variable APP_NAME is missing but required. Eg. \"cromwell\"}"


### PR DESCRIPTION
### Changes
* Bump ArgoCD base image version to 2.5.3
* Explicitly include python3 in container image (this seems to have been removed from the upstream image)
* Use numeric user in container image instead of `argocd`, else we get `Error: container has runAsNonRoot and image has non-numeric user (argocd), cannot verify user is non-root` on K8s
* Update legacy-configs-plugin script to rewrite all environment variables like ARGOCD_ENV_<NAME> as <NAME> (fix for [this](https://argocd-vault-plugin.readthedocs.io/en/stable/config/#argocd-240-environment-variable-prefix))
